### PR TITLE
remove ruby head from shared config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,10 @@ jobs:
         ruby:
           # See comment comes from https://github.com/ruby/setup-ruby#matrix-of-ruby-versions
           # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-          - '3.0'
+          - "3.0"
           - 3.1
           - 3.2
           - 3.3
-          - head
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "RSpec tests: Ruby ${{ matrix.ruby }}"
@@ -38,7 +37,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: head
+          ruby-version: 3.3
       - name: Run static type checks
         run: bundle exec srb tc
   rubocop:
@@ -50,6 +49,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: head
+          ruby-version: 3.3
       - name: Run style checks
         run: bundle exec rubocop


### PR DESCRIPTION
Some gem versions are incompatible with the nightly Ruby dev build, so we're removing it from our CI / CD config. We'll still run everything against the latest patch versions, but manually add new minor and major versions as they are released.