### PR TITLE
drop ruby 3.0 from matrix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          # See comment comes from https://github.com/ruby/setup-ruby#matrix-of-ruby-versions
-          # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-          - "3.0"
           - 3.1
           - 3.2
           - 3.3


### PR DESCRIPTION
Ruby 3.0 was [EOL](https://endoflife.date/ruby)'ed two weeks ago. Gems are starting to drop support, and that will cause our 3.0 builds to start failing on the `bundle install` step ([example](https://github.com/rubyatscale/danger-packwerk/actions/runs/8976316475/job/24652918448)).