### PR TITLE
add shared config for tagging new issues as "triage"

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,16 @@
+name: Label issues as "triage"
+
+on:
+  workflow_call:
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: triage


### PR DESCRIPTION
A shared config that we can use to add the "triage" label to new issues.

* https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues