### PR TITLE
add step to shared ci / cd workflows to notify on failure on main branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,3 +21,17 @@ jobs:
         if: ${{ steps.tag-and-push-gem.outputs.new_version == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  notify_on_failure:
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    steps:
+      - uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "${{ github.repository }}/${{ github.ref }}: FAILED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,17 @@ jobs:
           ruby-version: 3.3
       - name: Run style checks
         run: bundle exec rubocop
+  notify_on_failure:
+    runs-on: ubuntu-latest
+    needs: [rspec, static_type_check, rubocop]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    steps:
+      - uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "${{ github.repository }}/${{ github.ref }}: FAILED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }


### PR DESCRIPTION
If either the CD or CI workflow fails on the main branch, this step will send a notification to the core team's Slack channel.