### PR TITLE
make test command overridable in shared CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       test-command:
         description: 'The command to run tests'
         required: false
+        type: string
         default: 'bundle exec rspec'
 jobs:
   run_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,13 @@ name: CI
 
 on:
   workflow_call:
+    inputs:
+      test-command:
+        description: 'The command to run tests'
+        required: false
+        default: 'bundle exec rspec'
 jobs:
-  rspec:
+  run_tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -13,7 +18,7 @@ jobs:
           - 3.3
     env:
       BUNDLE_GEMFILE: Gemfile
-    name: "RSpec tests: Ruby ${{ matrix.ruby }}"
+    name: "Run tests: Ruby ${{ matrix.ruby }}"
     steps:
       - uses: actions/checkout@v4
       - name: Install ripgrep
@@ -24,7 +29,7 @@ jobs:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
       - name: Run tests
-        run: bundle exec rspec
+        run: ${{ inputs.test-command }}
   static_type_check:
     name: "Type Check"
     runs-on: ubuntu-latest
@@ -51,7 +56,7 @@ jobs:
         run: bundle exec rubocop
   notify_on_failure:
     runs-on: ubuntu-latest
-    needs: [rspec, static_type_check, rubocop]
+    needs: [run_tests, static_type_check, rubocop]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This PR makes the test command a [workflow input](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#example-of-onworkflow_callinputs) that defaults to Rspec but can be overridden if a repo uses a different testing library (like packwerk-extensions, which [uses](https://github.com/rubyatscale/packwerk-extensions/pull/54) minitest).

I [tested this](https://github.com/rubyatscale/packwerk-extensions/actions/runs/9161696818/job/25187177976) in packwerk-extensions by running the CI workflow against this branch (`uses: rubyatscale/shared-config/.github/workflows/ci.yml@jms/test_command_input`)