### PR TITLE
make it possible for CI workflow consumers to override linter command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: 'bundle exec rspec'
+      linter-command:
+        description: 'The command to run the linter'
+        required: false
+        type: string
+        default: 'bundle exec rubocop'
 jobs:
   run_tests:
     runs-on: ubuntu-latest
@@ -43,9 +48,9 @@ jobs:
           ruby-version: 3.3
       - name: Run static type checks
         run: bundle exec srb tc
-  rubocop:
+  run_linter:
     runs-on: ubuntu-latest
-    name: Rubocop
+    name: "Linter"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -53,8 +58,8 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: 3.3
-      - name: Run style checks
-        run: bundle exec rubocop
+      - name: Run linter
+        run: ${{ inputs.linter-command }}
   notify_on_failure:
     runs-on: ubuntu-latest
     needs: [run_tests, static_type_check, rubocop]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: ${{ inputs.linter-command }}
   notify_on_failure:
     runs-on: ubuntu-latest
-    needs: [run_tests, static_type_check, rubocop]
+    needs: [run_tests, static_type_check, run_linter]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
https://github.com/rubyatscale/bigrails-redis uses `standardrb` instead of `rubocop` to enforce style rules. Like the test command, workflow consumers should be able to override the linter command.

* https://github.com/rubyatscale/shared-config/pull/8