### PR TITLE
add verbose flag to rake release for debugging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,7 @@ jobs:
           GIT_EMAIL: ${{secrets.GUSTO_GIT_EMAIL}}
           GIT_NAME: ${{secrets.GUSTO_GIT_NAME}}
           RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+          RELEASE_COMMAND: rake release --backtrace
       - name: Create GitHub Release
         run: gh release create v${{steps.tag-and-push-gem.outputs.gem_version}} --generate-notes
         if: ${{ steps.tag-and-push-gem.outputs.new_version == 'true' }}


### PR DESCRIPTION
Why: `packs` is getting an error during `rake release` and we're not sure exactly why.

What: Specify the release command for [publish-rubygems-action](https://github.com/discourse/publish-rubygems-action).