### PR TITLE
Add Ruby 4.0 to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - 3.2
           - 3.3
           - 3.4
+          - 4.0
     env:
       BUNDLE_GEMFILE: Gemfile
     name: "Run tests: Ruby ${{ matrix.ruby }}"


### PR DESCRIPTION
## Summary

Adds Ruby 4.0 to the `run_tests` matrix in the shared CI workflow, so all repos using `rubyatscale/shared-config/.github/workflows/ci.yml` will automatically test against Ruby 4.0.

The `static_type_check` and `run_linter` jobs use a hardcoded `ruby-version: 3.4` and are unchanged.