### PR TITLE
Update GitHub Actions, add zizmor security linter, and configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,16 +3,16 @@ name: CD
 on:
   workflow_call:
 jobs:
-  deploy:
+  deploy: # zizmor: ignore[secrets-outside-env] reusable workflow; environments are managed by callers
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Tag and Push Gem
         id: tag-and-push-gem
-        uses: discourse/publish-rubygems-action@v3
+        uses: discourse/publish-rubygems-action@4bd305c65315cb691bad1e8de97a87aaf29a0a85 # v3
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           GIT_EMAIL: ${{secrets.GUSTO_GIT_EMAIL}}
@@ -24,12 +24,12 @@ jobs:
         if: ${{ steps.tag-and-push-gem.outputs.new_version == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  notify_on_failure:
+  notify_on_failure: # zizmor: ignore[secrets-outside-env] reusable workflow; environments are managed by callers
     runs-on: ubuntu-latest
     needs: [deploy]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
     steps:
-      - uses: slackapi/slack-github-action@v3
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,8 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Tag and Push Gem
         id: tag-and-push-gem
         uses: discourse/publish-rubygems-action@v3
@@ -17,6 +19,7 @@ jobs:
           GIT_NAME: ${{secrets.GUSTO_GIT_NAME}}
           RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
       - name: Create GitHub Release
+        # zizmor: ignore[template-injection] gem_version comes from a trusted prior step
         run: gh release create v${{steps.tag-and-push-gem.outputs.gem_version}} --generate-notes
         if: ${{ steps.tag-and-push-gem.outputs.new_version == 'true' }}
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Tag and Push Gem
         id: tag-and-push-gem
         uses: discourse/publish-rubygems-action@v3
@@ -25,13 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-      - uses: slackapi/slack-github-action@v1.25.0
+      - uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
-            {
-              "text": "${{ github.repository }}/${{ github.ref }}: FAILED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
+            text: "${{ github.repository }}/${{ github.ref }}: FAILED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     name: "Run tests: Ruby ${{ matrix.ruby }}"
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install ripgrep
         run: sudo apt-get install -y ripgrep
       - name: Set up Ruby ${{ matrix.ruby }}
@@ -36,12 +38,15 @@ jobs:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
       - name: Run tests
+        # zizmor: ignore[template-injection] workflow_call inputs are controlled by the caller
         run: ${{ inputs.test-command }}
   static_type_check:
     name: "Type Check"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -54,12 +59,15 @@ jobs:
     name: "Linter"
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           ruby-version: 3.4
       - name: Run linter
+        # zizmor: ignore[template-injection] workflow_call inputs are controlled by the caller
         run: ${{ inputs.linter-command }}
   notify_on_failure:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
       BUNDLE_GEMFILE: Gemfile
     name: "Run tests: Ruby ${{ matrix.ruby }}"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Install ripgrep
         run: sudo apt-get install -y ripgrep
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1
         with:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
@@ -44,11 +44,11 @@ jobs:
     name: "Type Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1
         with:
           bundler-cache: true
           ruby-version: 3.4
@@ -58,23 +58,23 @@ jobs:
     runs-on: ubuntu-latest
     name: "Linter"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1
         with:
           bundler-cache: true
           ruby-version: 3.4
       - name: Run linter
         # zizmor: ignore[template-injection] workflow_call inputs are controlled by the caller
         run: ${{ inputs.linter-command }}
-  notify_on_failure:
+  notify_on_failure: # zizmor: ignore[secrets-outside-env] reusable workflow; environments are managed by callers
     runs-on: ubuntu-latest
     needs: [run_tests, static_type_check, run_linter]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
     steps:
-      - uses: slackapi/slack-github-action@v3
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       BUNDLE_GEMFILE: Gemfile
     name: "Run tests: Ruby ${{ matrix.ruby }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install ripgrep
         run: sudo apt-get install -y ripgrep
       - name: Set up Ruby ${{ matrix.ruby }}
@@ -41,7 +41,7 @@ jobs:
     name: "Type Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Linter"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -65,13 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run_tests, static_type_check, run_linter]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-      - uses: slackapi/slack-github-action@v1.25.0
+      - uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
-            {
-              "text": "${{ github.repository }}/${{ github.ref }}: FAILED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            }
+            text: "${{ github.repository }}/${{ github.ref }}: FAILED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           stale-issue-message: 'This issue has been marked stale because it has been open for six months with no activity. To prevent this issue from automatically being closed in one week, update it or remove the stale label.'
           stale-pr-message: 'This PR has been marked stale because it has been open for six months with no activity. To prevent this PR from automatically being closed in one week, update it or remove the stale label.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: 'This issue has been marked stale because it has been open for six months with no activity. To prevent this issue from automatically being closed in one week, update it or remove the stale label.'
           stale-pr-message: 'This PR has been marked stale because it has been open for six months with no activity. To prevent this PR from automatically being closed in one week, update it or remove the stale label.'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@v0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,11 +17,9 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@v0.5.3
-        with:
-          config: .zizmor.yml
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,10 +16,8 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -23,3 +23,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@v0.5.3
+        with:
+          config: .zizmor.yml

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,4 +22,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@v0
+        uses: zizmorcore/zizmor-action@v0.5.3

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  unpinned-uses:
-    disable: true
-  secrets-outside-env:
-    disable: true

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    disable: true
+  secrets-outside-env:
+    disable: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
 # shared-config
+
+Shared reusable GitHub Actions workflows for [rubyatscale](https://github.com/rubyatscale) gems.
+
+## Workflows
+
+### Reusable workflows (`workflow_call`)
+
+These workflows are called from individual gem repos via `uses: rubyatscale/shared-config/.github/workflows/<name>.yml@main`.
+
+| Workflow | Description |
+|----------|-------------|
+| **CI** (`ci.yml`) | Runs tests across Ruby 3.2–4.0, Sorbet type checking, and linting (RuboCop). Test and linter commands are configurable via inputs. |
+| **CD** (`cd.yml`) | Publishes the gem to RubyGems and creates a GitHub Release on successful main builds. |
+| **Stale** (`stale.yml`) | Marks issues and PRs as stale after 180 days of inactivity, then closes them after 7 more days. |
+| **Triage** (`triage.yml`) | Labels new issues with `triage`. |
+
+### Repository workflows
+
+| Workflow | Description |
+|----------|-------------|
+| **zizmor** (`zizmor.yml`) | Runs the [zizmor](https://github.com/zizmorcore/zizmor) security linter against all workflow files on every push and PR. |
+
+## Usage
+
+In a gem repo, create a workflow that calls the shared workflow:
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    uses: rubyatscale/shared-config/.github/workflows/ci.yml@main
+```
+
+### CI inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `test-command` | `bundle exec rspec` | Command to run tests |
+| `linter-command` | `bundle exec rubocop` | Command to run the linter |
+
+### Required secrets
+
+The **CD** workflow requires the following secrets in the calling repo:
+
+- `GUSTO_GIT_EMAIL` / `GUSTO_GIT_NAME` — Git identity for tagging
+- `RUBYGEMS_API_KEY` — API key for publishing to RubyGems
+- `SLACK_WEBHOOK_URL` — Incoming webhook URL for failure notifications (used by both CI and CD)
+
+## Security
+
+- All action references are pinned to SHA hashes
+- [zizmor](https://github.com/zizmorcore/zizmor) runs on every PR to lint workflows for security issues
+- [Dependabot](https://docs.github.com/en/code-security/dependabot) is configured for monthly GitHub Actions updates


### PR DESCRIPTION
## Summary
- Update all GitHub Actions to their latest major versions: `actions/checkout` v4→v6, `slackapi/slack-github-action` v1→v3, `actions/stale` v9→v10
- Migrate `slackapi/slack-github-action` from v1 to v3 API (env vars → step inputs, JSON → YAML payload)
- Pin all action references to SHA hashes for supply chain security
- Add [zizmor](https://github.com/zizmorcore/zizmor) as a PR check to lint GitHub Actions workflows for security issues
- Add `persist-credentials: false` to all checkout steps (artipacked)
- Add inline zizmor ignores for findings intentional in reusable workflows (secrets-outside-env, template-injection on trusted inputs)
- Configure Dependabot for monthly GitHub Actions updates with cooldown
- Expand README with workflow documentation, usage examples, and required secrets

## Test plan
- [ ] Verify zizmor workflow passes on this PR
- [ ] Verify CI and CD workflows still function correctly in downstream repos
- [ ] Verify Dependabot picks up the config after merge