### PR TITLE
Drop Ruby 3.2 from CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.2
           - 3.3
           - 3.4
           - 4.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These workflows are called from individual gem repos via `uses: rubyatscale/shar
 
 | Workflow | Description |
 |----------|-------------|
-| **CI** (`ci.yml`) | Runs tests across Ruby 3.2–4.0, Sorbet type checking, and linting (RuboCop). Test and linter commands are configurable via inputs. |
+| **CI** (`ci.yml`) | Runs tests across Ruby 3.3–4.0, Sorbet type checking, and linting (RuboCop). Test and linter commands are configurable via inputs. |
 | **CD** (`cd.yml`) | Publishes the gem to RubyGems and creates a GitHub Release on successful main builds. |
 | **Stale** (`stale.yml`) | Marks issues and PRs as stale after 180 days of inactivity, then closes them after 7 more days. |
 | **Triage** (`triage.yml`) | Labels new issues with `triage`. |


### PR DESCRIPTION
## Summary

Removes Ruby 3.2 from the reusable CI workflow's test matrix.

Ruby 3.2 reached end of life, and the modern Sorbet/RBS toolchain now requires Ruby >= 3.3 (e.g. `rbi >= 0.3.12`). Repos consuming this shared workflow (such as [packwerk-extensions](https://github.com/rubyatscale/packwerk-extensions/pull/68)) fail their 3.2 job on `bundle install` because of this floor.

## Change

- `ci.yml`: test matrix is now `[3.3, 3.4, 4.0]` (was `[3.2, 3.3, 3.4, 4.0]`).
