### PR TITLE
Group Dependabot github-actions updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: monthly
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Groups Dependabot's `github-actions` updates so all action bumps land in a **single PR** instead of one PR per action.

PRs #20–23 (slackapi/slack-github-action, zizmorcore/zizmor-action, actions/stale, ruby/setup-ruby) were all opened on the same monthly run and should have been a single grouped PR.

## Change

Adds a `groups:` block with a wildcard pattern to the `github-actions` ecosystem in `.github/dependabot.yml`:

```yaml
groups:
  github-actions:
    patterns:
      - "*"
```
